### PR TITLE
Allow setting button colors from code

### DIFF
--- a/Pod/Classes/YAScrollSegmentControl.h
+++ b/Pod/Classes/YAScrollSegmentControl.h
@@ -27,6 +27,10 @@ IB_DESIGNABLE
 @property (nonatomic, assign) IBInspectable CGFloat gradientPercentage;
 @property (nonatomic, strong) IBInspectable UIColor *gradientColor;
 
+@property (nonatomic, strong) IBInspectable UIColor *buttonColor;
+@property (nonatomic, strong) IBInspectable UIColor *buttonHighlightColor;
+@property (nonatomic, strong) IBInspectable UIColor *buttonSelectedColor;
+
 @property (nonatomic, assign) NSInteger selectedIndex;
 
 @property (nonatomic, weak) IBOutlet id <YAScrollSegmentControlDelegate> delegate;

--- a/Pod/Classes/YAScrollSegmentControl.m
+++ b/Pod/Classes/YAScrollSegmentControl.m
@@ -26,10 +26,6 @@ static const CGFloat defaultGradientPercentage = 0.2;
 @property (nonatomic, strong) UIView *leftMask;
 @property (nonatomic, strong) UIView *rightMask;
 
-@property (nonatomic, strong) IBInspectable UIColor *buttonColor;
-@property (nonatomic, strong) IBInspectable UIColor *buttonHighlightColor;
-@property (nonatomic, strong) IBInspectable UIColor *buttonSelectedColor;
-
 @property (nonatomic, strong) IBInspectable UIImage *buttonBackgroundImage;
 @property (nonatomic, strong) IBInspectable UIImage *buttonHighlightedBackgroundImage;
 @property (nonatomic, strong) IBInspectable UIImage *buttonSelectedBackgroundImage;


### PR DESCRIPTION
Moved button colors to the header, so they can be set from code, not just from Interface Builder.